### PR TITLE
Spatial circle

### DIFF
--- a/JAG3D/src/org/applied_geodesy/juniform/test/SpatialCircleTest.java
+++ b/JAG3D/src/org/applied_geodesy/juniform/test/SpatialCircleTest.java
@@ -96,6 +96,6 @@ public class SpatialCircleTest extends NISTTest {
 		test2d.start("./nist/Circle2d/");
 		
 		NISTTest test3d = new SpatialCircleTest();
-		test3d.start("./nist/Circle3d/");
+		test3d.start("./nist/Circle3d_full/");
 	}
 }


### PR DESCRIPTION
- NIST data set was for circle3d test was changed because the former set was not related to a true orthogonal distance fit