### PR TITLE
Re-sort tables on adjustment failed

### DIFF
--- a/JAG3D/src/org/applied_geodesy/juniform/ui/dialog/FeatureAdjustmentDialog.java
+++ b/JAG3D/src/org/applied_geodesy/juniform/ui/dialog/FeatureAdjustmentDialog.java
@@ -523,11 +523,17 @@ public class FeatureAdjustmentDialog {
 					}
 					throwable.printStackTrace();
 				}
-				UITreeBuilder.getInstance().getTree().getSelectionModel().select(0);
-				UIPointTableBuilder.getInstance().getTable().refresh();
-				UIPointTableBuilder.getInstance().getTable().sort();
-				UIParameterTableBuilder.getInstance().getTable().refresh();
-				UIParameterTableBuilder.getInstance().getTable().sort();
+				try {
+					UIPointTableBuilder.getInstance().getTable().getSelectionModel().clearSelection();
+					UIPointTableBuilder.getInstance().getTable().refresh();
+					UIPointTableBuilder.getInstance().getTable().sort();
+					UIParameterTableBuilder.getInstance().getTable().getSelectionModel().clearSelection();
+					UIParameterTableBuilder.getInstance().getTable().refresh();
+					UIParameterTableBuilder.getInstance().getTable().sort();
+				}
+				catch (Exception e) {
+					e.printStackTrace();
+				}
 			}
 		});
 


### PR DESCRIPTION
- catched IndexOutOfBoundsException on re-sort table, if number of points are very large
- removed selection of the table rows (maybe, this prevents the exception)