### PR TITLE
Prevent IndexOutOfBoundException

### DIFF
--- a/JAG3D/src/org/applied_geodesy/juniform/ui/table/ParameterDoubleCell.java
+++ b/JAG3D/src/org/applied_geodesy/juniform/ui/table/ParameterDoubleCell.java
@@ -31,6 +31,7 @@ import org.applied_geodesy.util.FormatterEvent;
 import org.applied_geodesy.util.FormatterOptions;
 
 import javafx.geometry.Pos;
+import javafx.scene.control.TableRow;
 
 class ParameterDoubleCell extends EditableCell<UnknownParameter, Double> implements FormatterChangedListener {
 	private DisplayCellFormatType displayFormatType;
@@ -140,11 +141,18 @@ class ParameterDoubleCell extends EditableCell<UnknownParameter, Double> impleme
 	
 	@Override
 	public void formatterChanged(FormatterEvent evt) {
-		int idx = this.getTableRow().getIndex();
-		int itemSize = this.getTableView().getItems().size();
-		if (idx >= 0 && idx < itemSize) {
-			UnknownParameter paramRow = this.getTableView().getItems().get(idx);
-			this.setCellValueTypeOfUnknownParameter(paramRow);
-		}
+//		int idx = this.getTableRow().getIndex();
+//		int itemSize = this.getTableView().getItems().size();
+//		if (idx >= 0 && idx < itemSize) {
+//			UnknownParameter paramRow = this.getTableView().getItems().get(idx);
+//			this.setCellValueTypeOfUnknownParameter(paramRow);
+//		}
+		
+		TableRow<UnknownParameter> tableRow = this.getTableRow();
+		if (tableRow == null || tableRow.isEmpty() || this.getTableRow().getItem() == null)
+			return;
+		
+		UnknownParameter paramRow = this.getTableRow().getItem();
+		this.setCellValueTypeOfUnknownParameter(paramRow);
 	}
 }


### PR DESCRIPTION
- get row data by calling `getTableRow().getItem()` instead of using the underlying list of the table view to prevent an `IndexOutOfBoundException`