### PR TITLE
SQL

### DIFF
--- a/JAG3D/src/org/applied_geodesy/jag3d/ui/io/sql/OADBReader.java
+++ b/JAG3D/src/org/applied_geodesy/jag3d/ui/io/sql/OADBReader.java
@@ -441,6 +441,7 @@ public class OADBReader extends SourceFileReader<TreeItem<TreeItemValue>> {
 		
 		String sql = "SELECT "
 				+ "\"start_point_name\", \"end_point_name\", \"enable\" "
+				+ "FROM \"CongruenceAnalysisPointPairApriori\" "
 				+ "WHERE \"group_id\" = ? "
 				+ "ORDER BY \"id\" ASC";
 


### PR DESCRIPTION
- the data base table name `CongruenceAnalysisPointPairApriori` was missing in SQL statement and migration failed
- SQL statement correceted
- https://software.applied-geodesy.org/forum/?id=4814